### PR TITLE
Add course update endpoint

### DIFF
--- a/backend/app/api/routes/courses.py
+++ b/backend/app/api/routes/courses.py
@@ -19,7 +19,7 @@ from app.models.course import Course, Enrolment, EnrolmentStatus
 from app.models.material import Material
 from app.models.user import User
 from app.schemas.course import Course as CourseSchema
-from app.schemas.course import CourseCreate, Enrolment as EnrolmentSchema
+from app.schemas.course import CourseCreate, CourseUpdate, Enrolment as EnrolmentSchema
 from app.schemas.material import Material as MaterialSchema, MaterialList
 from app.services import courses
 
@@ -93,4 +93,16 @@ async def list_materials(
         items=materials,
         next_cursor=next_cursor,
         has_more=has_more
-    ) 
+    )
+
+
+@router.patch("/{course_id}", response_model=CourseSchema)
+async def update_course(
+    *,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    current_user: Annotated[User, Depends(get_current_user)],
+    course_id: int,
+    course_in: CourseUpdate,
+) -> CourseSchema:
+    """Update course."""
+    return await courses.update_course(db, current_user, course_id, course_in)

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from functools import lru_cache
-from typing import Any, List, AnyHttpUrl, PostgresDsn, RedisDsn, Union
+from typing import Any, List, Union
 
 from pydantic import AnyHttpUrl, PostgresDsn, RedisDsn, validator
 from pydantic_settings import BaseSettings, SettingsConfigDict

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -26,6 +26,9 @@ AsyncSessionLocal = async_sessionmaker(
     autoflush=False,
 )
 
+# Temporary alias for backward compatibility
+SessionLocal = AsyncSessionLocal
+
 
 async def get_db() -> AsyncGenerator[AsyncSession, None]:
     """Get database session."""


### PR DESCRIPTION
## Summary
- add PATCH /courses/{course_id}
- implement update_course service method with permission checks
- test updating courses and permission denial
- small fixes for config and session modules

## Testing
- `pytest tests/test_courses.py::test_update_course tests/test_courses.py::test_update_course_forbidden -q` *(fails: ImportError: cannot import name 'app.db.base_class')*

------
https://chatgpt.com/codex/tasks/task_e_6845cb73ceb88323b2e0a9bf54338326