### PR TITLE
Add telegram bind endpoint

### DIFF
--- a/backend/app/api/routes/telegram.py
+++ b/backend/app/api/routes/telegram.py
@@ -1,6 +1,8 @@
 from datetime import datetime, timedelta
 from typing import Annotated
 
+from sqlalchemy import select
+
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -8,7 +10,7 @@ from app.core.redis import get_redis
 from app.core.security import get_current_user
 from app.db.session import get_db
 from app.models.user import User
-from app.schemas.telegram import TelegramBindToken
+from app.schemas.telegram import TelegramBindToken, TelegramBindRequest
 
 router = APIRouter(prefix="/telegram", tags=["telegram"])
 
@@ -36,4 +38,34 @@ async def generate_bind_token(
         ex=900,  # 15 minutes
     )
 
-    return {"token": token} 
+    return {"token": token}
+
+
+@router.post("/bind")
+async def bind_account(
+    payload: TelegramBindRequest,
+    db: Annotated[AsyncSession, Depends(get_db)],
+) -> dict:
+    """Bind Telegram account using a token."""
+    redis = await get_redis()
+    token_key = f"telegram:bind_token:{payload.token}"
+    token_data_raw = await redis.get(token_key)
+    if not token_data_raw:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid or expired token")
+    try:
+        token_data = TelegramBindToken.parse_raw(token_data_raw)
+    except Exception:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid token")
+    if datetime.utcnow() > token_data.expires_at:
+        await redis.delete(token_key)
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Token has expired")
+
+    result = await db.execute(select(User).where(User.id == token_data.user_id))
+    user = result.scalar_one_or_none()
+    if not user:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+
+    setattr(user, "telegram_id", payload.telegram_id)
+    await db.commit()
+    await redis.delete(token_key)
+    return {"message": "Telegram account bound"}

--- a/backend/app/schemas/telegram.py
+++ b/backend/app/schemas/telegram.py
@@ -3,6 +3,13 @@ from datetime import datetime
 from pydantic import BaseModel
 
 
+class TelegramBindRequest(BaseModel):
+    """Request body for binding Telegram account."""
+
+    token: str
+    telegram_id: int
+
+
 class TelegramBindToken(BaseModel):
     """Telegram bind token schema."""
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -27,3 +27,8 @@ npm run dev
 ```sh
 npm run build
 ```
+
+### Telegram API
+
+- `POST /auth/telegram/bind-token` — generate a Telegram binding token.
+- `POST /auth/telegram/bind` — bind a Telegram account using the token.

--- a/tests/test_telegram.py
+++ b/tests/test_telegram.py
@@ -1,1 +1,40 @@
- 
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.security import get_password_hash
+from app.models.user import User
+
+
+@pytest.mark.asyncio
+async def test_generate_and_bind(async_client: AsyncClient, db: AsyncSession) -> None:
+    user = User(
+        email="tg@example.com",
+        first_name="TG",
+        last_name="User",
+        password_hash=get_password_hash("pass"),
+    )
+    db.add(user)
+    await db.commit()
+
+    login_resp = await async_client.post(
+        "/auth/login",
+        data={"username": "tg@example.com", "password": "pass"},
+    )
+    access = login_resp.json()["access_token"]
+
+    token_resp = await async_client.post(
+        "/telegram/bind-token",
+        headers={"Authorization": f"Bearer {access}"},
+    )
+    assert token_resp.status_code == 200
+    token = token_resp.json()["token"]
+
+    bind_resp = await async_client.post(
+        "/auth/telegram/bind",
+        json={"token": token, "telegram_id": 123},
+    )
+    assert bind_resp.status_code == 200
+    assert bind_resp.json()["message"] == "Telegram account bound"


### PR DESCRIPTION
## Summary
- allow binding Telegram account via `/auth/telegram/bind`
- extend Telegram schema
- document telegram API
- add test for binding flow

## Testing
- `pytest -q` *(fails: ImportError due to missing AnyHttpUrl from typing)*

------
https://chatgpt.com/codex/tasks/task_e_6845cb772dec83238aaab5d7c44ec6e6