### PR TITLE
Add traefik service to compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,23 @@ services:
       - postgres
       - redis
 
+  traefik:
+    image: traefik:v2.10
+    command:
+      - "--api.insecure=true"
+      - "--providers.docker=true"
+      - "--providers.docker.exposedbydefault=false"
+      - "--entrypoints.web.address=:80"
+      - "--entrypoints.websecure.address=:443"
+    ports:
+      - "80:80"
+      - "443:443"
+      - "8080:8080"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    environment:
+      - DOMAIN=${DOMAIN:-localhost}
+
 volumes:
   postgres_data:
   redis_data: 


### PR DESCRIPTION
## Summary
- extend development docker-compose with a traefik service
- allow domain auto-substitution via `DOMAIN` env var

## Testing
- `pytest -q` *(fails: No module named 'pytest_asyncio')*
- `pip install -r backend/requirements.txt` *(fails: Could not find a version that satisfies the requirement telegram==20.8)*

------
https://chatgpt.com/codex/tasks/task_e_6845cb6c244c8323aee21f8454833d3f